### PR TITLE
Corrected typo and added auto resize UIImage

### DIFF
--- a/UICheckbox/UICheckbox.h
+++ b/UICheckbox/UICheckbox.h
@@ -31,8 +31,8 @@
 @property (nonatomic, assign) BOOL disabled;
 @property (nonatomic, strong) NSString *text;
 
-@property (nonatomic, strong) NSString *imageNameCheched;
-@property (nonatomic, strong) NSString *imageNameNoCheched;
+@property (nonatomic, strong) NSString *imageNameChecked;
+@property (nonatomic, strong) NSString *imageNameNoChecked;
 
 @property (nonatomic, strong) id<UICheckBoxDelegate>delegate;
 

--- a/UICheckbox/UICheckbox.m
+++ b/UICheckbox/UICheckbox.m
@@ -32,17 +32,22 @@
 
 - (void) drawRect:(CGRect)rect
 {
-    if (_imageNameCheched && _imageNameNoCheched)
+    if (_imageNameChecked && _imageNameNoChecked)
     {
-        _image = [UIImage imageNamed:_checked ? _imageNameCheched : _imageNameNoCheched];
+        _image = [UIImage imageNamed:_checked ? _imageNameChecked : _imageNameNoChecked];
     }
     
-    if(!_image || !_imageNameCheched || !_imageNameNoCheched)
+    if(!_image || !_imageNameChecked || !_imageNameNoChecked)
     {
         _image = [UIImage imageNamed:[NSString stringWithFormat:@"uicheckbox_%@checked.png", _checked ? @"" : @"un"]];
     }
+
+    UIGraphicsBeginImageContextWithOptions(self.frame.size, NO, 0.0);
+    [_image drawInRect:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
+    _image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
     
-    [_image drawInRect:CGRectMake((self.frame.size.width - _image.size.width) / 2.0f, (self.frame.size.height - _image.size.height) / 2.0f, _image.size.width, _image.size.height)];
+    [_image drawAsPatternInRect:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
     
     if(_disabled)
     {


### PR DESCRIPTION
Hi, thanks for your awesome pod.
I have used your library in my project and found a typo in the code.
Also, I realized that by only setting the image names for checked and unchecked states, my images were not rendered correctly. (not scaled correctly to fit the frame)
So I made some changes to auto resize the image according to the frame of `UICheckbox`.
Please take a look. Thank you!
