### PR TITLE
Make delegate weak

### DIFF
--- a/UICheckbox/UICheckbox.h
+++ b/UICheckbox/UICheckbox.h
@@ -34,6 +34,6 @@
 @property (nonatomic, strong) NSString *imageNameChecked;
 @property (nonatomic, strong) NSString *imageNameNoChecked;
 
-@property (nonatomic, strong) id<UICheckBoxDelegate>delegate;
+@property (nonatomic, weak) id<UICheckBoxDelegate>delegate;
 
 @end


### PR DESCRIPTION
Make UICheckbox's delegate weak to avoid retain cycles.
If delegate is strong, ViewController with installed checkbox will not be unloaded from memory because retain count is not dropped to 0.